### PR TITLE
Add basic users feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
     "@prisma/client": "6.7.0",
+    "pino": "^8.17.0",
+    "zod": "^3.22.4",
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { HealthController } from './healthz/healthz.controller';
 import { PrismaModule } from './infrastructure/prisma/prisma.module';
+import { UsersModule } from './interface/http/users/users.module';
+import { PinoProvider } from './infrastructure/logger/pino.provider';
 
 
 @Module({
@@ -14,8 +16,9 @@ import { PrismaModule } from './infrastructure/prisma/prisma.module';
       ]
     }),
     PrismaModule,
+    UsersModule,
   ],
   controllers: [HealthController],
-  providers: [],
+  providers: [PinoProvider],
 })
 export class AppModule {}

--- a/src/application/users/create-user.input.ts
+++ b/src/application/users/create-user.input.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const CreateUserSchema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  password: z.string().min(6),
+});
+
+export type CreateUserInput = z.infer<typeof CreateUserSchema>;

--- a/src/application/users/create-user.use-case.ts
+++ b/src/application/users/create-user.use-case.ts
@@ -1,0 +1,33 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { UserRepository } from '../../domain/users/user.repository';
+import { User } from '../../domain/users/user.entity';
+import { UserStatus } from '../../domain/users/user-status.enum';
+import { UserType } from '../../domain/users/user-type.enum';
+import { CreateUserInput } from './create-user.input';
+import { ok, err, Result } from '../../shared/result';
+import * as bcrypt from 'bcrypt';
+
+@Injectable()
+export class CreateUserUseCase {
+  constructor(@Inject('UserRepository') private readonly repo: UserRepository) {}
+
+  async execute(data: CreateUserInput): Promise<Result<User, string>> {
+    const hashed = await bcrypt.hash(data.password, 10);
+    try {
+      const user = new User(
+        '',
+        data.name,
+        data.email,
+        hashed,
+        UserStatus.ACTIVE,
+        UserType.EMPLOYEE,
+        new Date(),
+        new Date(),
+      );
+      const created = await this.repo.create(user);
+      return ok(created);
+    } catch (e: any) {
+      return err('failed to create user');
+    }
+  }
+}

--- a/src/application/users/get-user.use-case.ts
+++ b/src/application/users/get-user.use-case.ts
@@ -1,0 +1,15 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { UserRepository } from '../../domain/users/user.repository';
+import { User } from '../../domain/users/user.entity';
+import { ok, err, Result } from '../../shared/result';
+
+@Injectable()
+export class GetUserUseCase {
+  constructor(@Inject('UserRepository') private readonly repo: UserRepository) {}
+
+  async execute(id: string): Promise<Result<User, string>> {
+    const user = await this.repo.findById(id);
+    if (!user) return err('user not found');
+    return ok(user);
+  }
+}

--- a/src/domain/users/user-status.enum.ts
+++ b/src/domain/users/user-status.enum.ts
@@ -1,0 +1,6 @@
+export enum UserStatus {
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
+  BLOCKED = 'BLOCKED',
+  DELETED = 'DELETED',
+}

--- a/src/domain/users/user-type.enum.ts
+++ b/src/domain/users/user-type.enum.ts
@@ -1,0 +1,5 @@
+export enum UserType {
+  GLOBAL_ADMIN = 'GLOBAL_ADMIN',
+  COMPANY_ADMIN = 'COMPANY_ADMIN',
+  EMPLOYEE = 'EMPLOYEE',
+}

--- a/src/domain/users/user.entity.ts
+++ b/src/domain/users/user.entity.ts
@@ -1,0 +1,15 @@
+import { UserStatus } from './user-status.enum';
+import { UserType } from './user-type.enum';
+
+export class User {
+  constructor(
+    public id: string,
+    public name: string,
+    public email: string,
+    public password: string,
+    public status: UserStatus,
+    public type: UserType,
+    public createdAt: Date,
+    public updatedAt: Date,
+  ) {}
+}

--- a/src/domain/users/user.repository.ts
+++ b/src/domain/users/user.repository.ts
@@ -1,0 +1,6 @@
+import { User } from './user.entity';
+
+export abstract class UserRepository {
+  abstract create(user: User): Promise<User>;
+  abstract findById(id: string): Promise<User | null>;
+}

--- a/src/infrastructure/logger/pino.provider.ts
+++ b/src/infrastructure/logger/pino.provider.ts
@@ -1,0 +1,7 @@
+import pino from 'pino';
+import { Provider } from '@nestjs/common';
+
+export const PinoProvider: Provider = {
+  provide: 'Logger',
+  useFactory: () => pino({ level: 'info' }),
+};

--- a/src/infrastructure/users/prisma-user.repository.ts
+++ b/src/infrastructure/users/prisma-user.repository.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { UserRepository } from '../../domain/users/user.repository';
+import { User } from '../../domain/users/user.entity';
+import { UserMapper } from './user.mapper';
+
+@Injectable()
+export class PrismaUserRepository implements UserRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(user: User): Promise<User> {
+    const created = await this.prisma.user.create({
+      data: {
+        name: user.name,
+        email: user.email,
+        password: user.password,
+      },
+    });
+    return UserMapper.toDomain(created);
+  }
+
+  async findById(id: string): Promise<User | null> {
+    const found = await this.prisma.user.findUnique({
+      where: { id },
+      include: {
+        accessLevels: { include: { level: true } },
+        directPermissions: { include: { permission: true } },
+      },
+    });
+    return found ? UserMapper.toDomain(found) : null;
+  }
+}

--- a/src/infrastructure/users/user.mapper.ts
+++ b/src/infrastructure/users/user.mapper.ts
@@ -1,0 +1,19 @@
+import { User } from '../../domain/users/user.entity';
+import { User as PrismaUser, UserStatus as PrismaStatus, UserType as PrismaType } from '@prisma/client';
+import { UserStatus } from '../../domain/users/user-status.enum';
+import { UserType } from '../../domain/users/user-type.enum';
+
+export class UserMapper {
+  static toDomain(prisma: PrismaUser): User {
+    return new User(
+      prisma.id,
+      prisma.name,
+      prisma.email,
+      prisma.password,
+      prisma.status as UserStatus,
+      prisma.user_type as unknown as UserType,
+      prisma.createdAt,
+      prisma.updatedAt,
+    );
+  }
+}

--- a/src/interface/http/users/dtos/create-user.dto.ts
+++ b/src/interface/http/users/dtos/create-user.dto.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const CreateUserBodySchema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  password: z.string().min(6),
+});
+
+export type CreateUserDto = z.infer<typeof CreateUserBodySchema>;

--- a/src/interface/http/users/dtos/user-response.dto.ts
+++ b/src/interface/http/users/dtos/user-response.dto.ts
@@ -1,0 +1,9 @@
+export interface UserResponseDto {
+  id: string;
+  name: string;
+  email: string;
+  status: string;
+  type: string;
+  accessLevels: string[];
+  directPermissions: string[];
+}

--- a/src/interface/http/users/user.presenter.ts
+++ b/src/interface/http/users/user.presenter.ts
@@ -1,0 +1,12 @@
+import { User } from '../../../domain/users/user.entity';
+import { UserResponseDto } from './dtos/user-response.dto';
+
+export const userToDto = (user: User): UserResponseDto => ({
+  id: user.id,
+  name: user.name,
+  email: user.email,
+  status: user.status,
+  type: user.type,
+  accessLevels: [],
+  directPermissions: [],
+});

--- a/src/interface/http/users/users.controller.ts
+++ b/src/interface/http/users/users.controller.ts
@@ -1,0 +1,33 @@
+import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post } from '@nestjs/common';
+import { CreateUserUseCase } from '../../../application/users/create-user.use-case';
+import { GetUserUseCase } from '../../../application/users/get-user.use-case';
+import { CreateUserBodySchema, CreateUserDto } from './dtos/create-user.dto';
+import { userToDto } from './user.presenter';
+
+@Controller('users')
+export class UsersController {
+  constructor(
+    private readonly createUser: CreateUserUseCase,
+    private readonly getUser: GetUserUseCase,
+  ) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async create(@Body() body: any) {
+    const dto: CreateUserDto = CreateUserBodySchema.parse(body);
+    const result = await this.createUser.execute(dto);
+    if (!result.ok) {
+      return { message: result.error };
+    }
+    return userToDto(result.value);
+  }
+
+  @Get(':id')
+  async findOne(@Param('id') id: string) {
+    const result = await this.getUser.execute(id);
+    if (!result.ok) {
+      return { message: result.error };
+    }
+    return userToDto(result.value);
+  }
+}

--- a/src/interface/http/users/users.module.ts
+++ b/src/interface/http/users/users.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { UsersController } from './users.controller';
+import { CreateUserUseCase } from '../../../application/users/create-user.use-case';
+import { GetUserUseCase } from '../../../application/users/get-user.use-case';
+import { PrismaUserRepository } from '../../../infrastructure/users/prisma-user.repository';
+import { PrismaModule } from '../../../infrastructure/prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [UsersController],
+  providers: [
+    CreateUserUseCase,
+    GetUserUseCase,
+    { provide: 'UserRepository', useClass: PrismaUserRepository },
+  ],
+})
+export class UsersModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,11 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { PinoProvider } from './infrastructure/logger/pino.provider';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, { logger: false });
+  const logger = app.get('Logger') as ReturnType<typeof PinoProvider.useFactory>;
+  app.useLogger(logger);
   await app.listen(process.env.PORT ?? 3334);
 }
 bootstrap();

--- a/src/shared/result.ts
+++ b/src/shared/result.ts
@@ -1,0 +1,4 @@
+export type Result<R, L> = { ok: true; value: R } | { ok: false; error: L };
+
+export const ok = <R, L = never>(value: R): Result<R, L> => ({ ok: true, value });
+export const err = <R = never, L = unknown>(error: L): Result<R, L> => ({ ok: false, error });

--- a/test/users.e2e-spec.ts
+++ b/test/users.e2e-spec.ts
@@ -1,0 +1,36 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+describe('UsersController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  it('/users (POST)', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/users')
+      .send({ name: 'John', email: 'john@example.com', password: 'secret12' })
+      .expect(201);
+    expect(res.body).toHaveProperty('id');
+  });
+
+  it('/users/:id (GET)', async () => {
+    const create = await request(app.getHttpServer())
+      .post('/users')
+      .send({ name: 'Mary', email: 'mary@example.com', password: 'secret12' })
+      .expect(201);
+    const id = create.body.id;
+    await request(app.getHttpServer())
+      .get(`/users/${id}`)
+      .expect(200);
+  });
+});


### PR DESCRIPTION
## Summary
- set up user enums, entity, repository and mappers
- implement `Result` helper
- create `CreateUserUseCase` and `GetUserUseCase`
- expose endpoints in `UsersController`
- wire PrismaUserRepository and Pino logger
- basic e2e tests

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854440e06d4832185a833c009addcf5